### PR TITLE
feat: can invoke method when remove node from list

### DIFF
--- a/LruCacheNet/LruCache.cs
+++ b/LruCacheNet/LruCache.cs
@@ -24,6 +24,7 @@ namespace LruCacheNet
         private object _lock;
         private UpdateDataMethod _updateMethod;
         private CreateCopyMethod _createMethod;
+        private PreRemoveDataMethod _removeDataMethod;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LruCache{TKey,TValue}"/> class with the default size of 1000 items
@@ -66,6 +67,14 @@ namespace LruCacheNet
         /// <param name="data">Data to copy</param>
         /// <returns>New copy of data</returns>
         public delegate TValue CreateCopyMethod(TValue data);
+
+        /// <summary>
+        /// A method to callback with a data item of an item to remove from the cache 
+        /// </summary>
+        /// <param name="data">Data to delete</param>
+        /// <returns>True if callback is success, false if it was failed</returns>
+        public delegate bool PreRemoveDataMethod(TValue data);
+
 
         /// <summary>
         /// Event fired when the contents of the cache change
@@ -148,7 +157,16 @@ namespace LruCacheNet
         {
             _createMethod = method;
         }
-
+        
+        /// <summary>
+        /// Sets the method to call when before data remove in the cache
+        /// </summary>
+        /// <param name="method">Copy method to call</param>
+        public void SetPreRemoveDataMethod(PreRemoveDataMethod method)
+        {
+            _removeDataMethod = method;
+        }
+        
         /// <summary>
         /// Adds an item to the cache or updates its values if already in the cache
         /// If the item already existed in the cache it will also be moved to the front
@@ -513,6 +531,7 @@ namespace LruCacheNet
         /// <param name="node">Node to remove</param>
         private void RemoveNodeFromList(Node<TKey, TValue> node)
         {
+            _removeDataMethod?.Invoke(node.Value);
             _data.Remove(node.Key);
             if (node.Previous != null)
             {

--- a/UnitTests/CacheTests.cs
+++ b/UnitTests/CacheTests.cs
@@ -162,6 +162,43 @@ namespace UnitTests
         }
 
         [TestMethod, TestCategory("Cache")]
+        public void RemoveItem()
+        {
+            var cache = new LruCache<string, TestData>(10);
+            var data = new TestData
+            {
+                TestValue1 = "null",
+                TestValue2 = "null",
+            };
+                
+            cache.SetPreRemoveDataMethod(value =>
+            {
+                data.TestValue1 = value.TestValue1;
+                data.TestValue2 = value.TestValue2;
+                return true;
+            });
+            
+            cache.AddOrUpdate("1", new TestData
+            {
+                TestValue1 = "10",
+                TestValue2 = "20"
+            });
+            cache.AddOrUpdate("2", new TestData
+            {
+                TestValue1 = "30",
+                TestValue2 = "40"
+            });
+
+            cache.Remove("1");
+            Assert.Equals("10", data.TestValue1);
+            Assert.Equals("20", data.TestValue2);
+            
+            cache.Remove("2");
+            Assert.Equals("30", data.TestValue1);
+            Assert.Equals("40", data.TestValue2);
+        }
+
+        [TestMethod, TestCategory("Cache")]
         public void UpdateItem()
         {
             var cache = new LruCache<string, TestData>(10);


### PR DESCRIPTION
Previously, there was no way to process a value before removing it, so it was difficult to dispose a value or delete it from memory. So, before the value is removed, it allows you to do things like work on that value. 